### PR TITLE
Oct2022 update for Rokt Tag Integration

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -15,5 +15,13 @@
 homepage: "https://www.rokt.com"
 documentation: "https://docs.rokt.com/docs/developers/integration-guides/third-party-integrations/google-tag-manager/google-tag-template"
 versions:
+  # Latest version
+  - sha: c1363d3c7cb3b655ee51443a719e32994561472c
+    changeNotes: |2
+      Add advanced option to use pageIdentifier
+      Add advanced option to hash raw email attribute
+      Add support for multiple placements call
+      Remove support for MD5-hashed email attribute
+  # Older versions
   - sha: 6b69359f8adbfa6b97a5d3d179931fb3b5796416
     changeNotes: Initial release.


### PR DESCRIPTION
Hot new updates for Rokt tag template:
- Add advanced option to use pageIdentifier
- Add advanced option to hash raw email attribute
- Add support for multiple placements call
- Remove support for MD5-hashed email attribute

Note: updated wrapper & .tpl files have been uploaded to the [S3 bucket](https://s3.console.aws.amazon.com/s3/buckets/rokt-master-files-us?region=us-east-1&prefix=store%2Fjs%2F&showversions=false)