### PR TITLE
Update .tpl to add custom event listeners

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,10 +16,14 @@ homepage: 'https://www.rokt.com'
 documentation: 'https://docs.rokt.com/docs/developers/integration-guides/third-party-integrations/google-tag-manager/google-tag-template'
 versions:
   # Latest version
+  - sha: 25d59b6883789ef32bc6569697b725703bd5bd24
+    changeNotes: |2
+      Add Event Listeners attribute to More Integration Options
+      Add Country attribute field back in
+  # Older versions
   - sha: 7973ef444a311d20a2031c14bb802239c2522ded
     changeNotes: |2
       Add Country attribute field
-  # Older versions
   - sha: 75114416feafa11e1380e3cbdd51fd1fe1dd640d
     changeNotes: |2
       Add Payments Marketplace-specific attributes (i.e. cartItems, siteCountry, siteLanguage).

--- a/template.tpl
+++ b/template.tpl
@@ -1,4 +1,12 @@
-﻿___INFO___
+﻿___TERMS_OF_SERVICE___
+
+By creating or modifying this file you agree to Google Tag Manager's Community
+Template Gallery Developer Terms of Service available at
+https://developers.google.com/tag-manager/gallery-tos (or such other URL as
+Google may provide), as modified from time to time.
+
+
+___INFO___
 
 {
   "type": "TAG",
@@ -134,12 +142,6 @@ ___TEMPLATE_PARAMETERS___
         "type": "TEXT",
         "name": "state",
         "displayName": "State",
-        "simpleValueType": true
-      },
-      {
-        "type": "TEXT",
-        "name": "country",
-        "displayName": "Country",
         "simpleValueType": true
       },
       {
@@ -309,6 +311,49 @@ ___TEMPLATE_PARAMETERS___
         "displayName": "Disallow Targeting Cookies",
         "simpleValueType": true,
         "help": "Should dynamically reflect your user\u0027s targeting cookie consent state. Accepts a true or false Boolean."
+      },
+      {
+        "type": "SIMPLE_TABLE",
+        "name": "eventListeners",
+        "displayName": "Event Listeners",
+        "simpleTableColumns": [
+          {
+            "defaultValue": "",
+            "displayName": "Custom Name",
+            "name": "customName",
+            "type": "TEXT"
+          },
+          {
+            "defaultValue": "",
+            "displayName": "Rokt Event",
+            "name": "roktEvent",
+            "type": "SELECT",
+            "selectItems": [
+              {
+                "value": "OFFER_ENGAGEMENT",
+                "displayValue": "OFFER_ENGAGEMENT"
+              },
+              {
+                "value": "POSITIVE_ENGAGEMENT",
+                "displayValue": "POSITIVE_ENGAGEMENT"
+              },
+              {
+                "value": "PLACEMENT_CLOSED",
+                "displayValue": "PLACEMENT_CLOSED"
+              },
+              {
+                "value": "PLACEMENT_INTERACTIVE",
+                "displayValue": "PLACEMENT_INTERACTIVE"
+              },
+              {
+                "value": "PLACEMENT_READY",
+                "displayValue": "PLACEMENT_READY"
+              }
+            ]
+          }
+        ],
+        "help": "Add a custom field that maps to a certain Rokt event. When that Rokt event fires, a variable with that custom name will be added to the data layer.",
+        "newRowButtonText": "Add Event Listener"
       }
     ],
     "displayName": "More Integration Options"
@@ -346,6 +391,7 @@ cfg.pageIdentifier = data.pageIdentifier;
 cfg.hashRawEmail = data.hashRawEmail;
 cfg.noFunctional = data.noFunctional;
 cfg.noTargeting = data.noTargeting;
+cfg.eventListeners = data.eventListeners;
 
 // B.1 - Add core attributes
 for (const keyPair of Object.entries(data)) {
@@ -362,6 +408,7 @@ for (const keyPair of Object.entries(data)) {
     (keyPair[0] != 'hashRawEmail') &
     (keyPair[0] != 'noFunctional') &
     (keyPair[0] != 'noTargeting') &
+    (keyPair[0] != 'eventListeners') &
     (keyBeginning.substring(0, 4) !== 'rokt') &
     (keyBeginning.substring(0, 3) !== 'gtm')
   ) {

--- a/template.tpl
+++ b/template.tpl
@@ -146,6 +146,12 @@ ___TEMPLATE_PARAMETERS___
       },
       {
         "type": "TEXT",
+        "name": "country",
+        "displayName": "Country",
+        "simpleValueType": true
+      },
+      {
+        "type": "TEXT",
         "name": "clientcustomerid",
         "displayName": "Client customer ID",
         "simpleValueType": true


### PR DESCRIPTION
Updated .tpl to add Event Listeners field that map custom events to Rokt events (e.g. PLACEMENT_INTERACTIVE, etc.) so users don't have to listen for our specific events, and they can add custom events to dataLayer when our events fire.